### PR TITLE
feat (VIS-114): métricas de quantidade de talhão por analista

### DIFF
--- a/src/main/java/coderhood/controller/UserController.java
+++ b/src/main/java/coderhood/controller/UserController.java
@@ -88,4 +88,20 @@ public class UserController {
     public List<UserResponseDto> getAllUsers() {
         return userService.getAllUsers();
     }
+
+    @Operation(summary = "Buscar estatísticas dos analistas")
+    @ApiResponse(responseCode = "200", description = "Estatísticas dos analistas encontradas",
+        content = @Content(schema = @Schema(implementation = AnalistaEstatisticasDto.class)))
+    @GetMapping("/analistas/estatisticas")
+    public List<AnalistaEstatisticasDto> getAnalistasEstatisticas() {
+        return userService.getAnalistasEstatisticas();
+    }
+
+    @Operation(summary = "Buscar todos os analistas")
+    @ApiResponse(responseCode = "200", description = "Analistas encontrados",
+        content = @Content(schema = @Schema(implementation = UserResponseDto.class)))
+    @GetMapping("/analistas")
+    public List<UserResponseDto> getAnalistas() {
+        return userService.getAnalistas();
+    }
 }

--- a/src/main/java/coderhood/dto/AnalistaEstatisticasDto.java
+++ b/src/main/java/coderhood/dto/AnalistaEstatisticasDto.java
@@ -12,6 +12,6 @@ public class AnalistaEstatisticasDto {
     private String nome;
     private String email;
     private Long quantidadeTalhoes;
-    private Long horasAnalisadas; // Pode ser implementado futuramente
+    private Long horasAnalisadas;
     private Integer numeroNomeAnalyst;
 }

--- a/src/main/java/coderhood/dto/AnalistaEstatisticasDto.java
+++ b/src/main/java/coderhood/dto/AnalistaEstatisticasDto.java
@@ -1,0 +1,17 @@
+package coderhood.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnalistaEstatisticasDto {
+    private Long id;
+    private String nome;
+    private String email;
+    private Long quantidadeTalhoes;
+    private Long horasAnalisadas; // Pode ser implementado futuramente
+    private Integer numeroNomeAnalyst;
+}

--- a/src/main/java/coderhood/dto/TalhaoDto.java
+++ b/src/main/java/coderhood/dto/TalhaoDto.java
@@ -19,4 +19,5 @@ public class TalhaoDto {
     private Double produtividadePorAno;
     private StatusArea status = StatusArea.EM_ABERTO;
     private List<String> ervasDaninhas;
+    private Long analistaId;
 }

--- a/src/main/java/coderhood/model/Talhao.java
+++ b/src/main/java/coderhood/model/Talhao.java
@@ -47,6 +47,9 @@ public class Talhao {
     @Column(name = "data_aprovacao")
     private LocalDateTime dataAprovacao;
 
+    @Column(name = "analista_id")
+    private Long analistaId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "area_id", nullable = false)
     @JsonBackReference

--- a/src/main/java/coderhood/repository/TalhaoRepository.java
+++ b/src/main/java/coderhood/repository/TalhaoRepository.java
@@ -1,0 +1,14 @@
+package coderhood.repository;
+
+import coderhood.model.Talhao;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TalhaoRepository extends JpaRepository<Talhao, Long> {
+    
+    @Query("SELECT COUNT(t) FROM Talhao t WHERE t.analistaId = :analistaId")
+    Long countByAnalistaId(@Param("analistaId") Long analistaId);
+}

--- a/src/main/java/coderhood/repository/UserRepository.java
+++ b/src/main/java/coderhood/repository/UserRepository.java
@@ -3,9 +3,11 @@ package coderhood.repository;
 import coderhood.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+    List<User> findByTipoAcesso(User.TipoAcesso tipoAcesso);
 }

--- a/src/main/java/coderhood/service/AreaService.java
+++ b/src/main/java/coderhood/service/AreaService.java
@@ -303,6 +303,7 @@ public class AreaService {
         talhao.setProdutividadePorAno(talhaoDto.getProdutividadePorAno());
         talhao.setGeojson(talhaoDto.getGeojson());
         talhao.setStatus(talhaoDto.getStatus() != null ? talhaoDto.getStatus() : StatusArea.EM_ABERTO);
+        talhao.setAnalistaId(talhaoDto.getAnalistaId());
 
         if (talhaoDto.getErvasDaninhas() != null) {
             log.debug("Atualizando ervas daninhas: {}", talhaoDto.getErvasDaninhas());
@@ -379,6 +380,7 @@ public class AreaService {
         talhao.setProdutividadePorAno(talhaoDto.getProdutividadePorAno());
         talhao.setGeojson(talhaoDto.getGeojson());
         talhao.setStatus(talhaoDto.getStatus() != null ? talhaoDto.getStatus() : StatusArea.EM_ABERTO);
+        talhao.setAnalistaId(talhaoDto.getAnalistaId());
 
         if (talhaoDto.getErvasDaninhas() != null) {
             log.debug("Adicionando ervas daninhas: {}", talhaoDto.getErvasDaninhas());

--- a/src/main/java/coderhood/service/UserService.java
+++ b/src/main/java/coderhood/service/UserService.java
@@ -5,6 +5,7 @@ import coderhood.exception.ResourceNotFoundException;
 import coderhood.exception.BusinessRuleException;
 import coderhood.model.User;
 import coderhood.repository.UserRepository;
+import coderhood.repository.TalhaoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -21,6 +23,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final TalhaoRepository talhaoRepository;
 
     @Transactional(readOnly = true)
     public UserResponseDto getUserById(Long id) { // Mudou para Long
@@ -80,6 +83,38 @@ public class UserService {
             throw new ResourceNotFoundException("Usuário não encontrado");
         }
         userRepository.deleteById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AnalistaEstatisticasDto> getAnalistasEstatisticas() {
+        log.info("Obtendo estatísticas dos analistas");
+        
+        List<User> analistas = userRepository.findByTipoAcesso(User.TipoAcesso.ANALISTA);
+        AtomicInteger numeroSequencial = new AtomicInteger(1);
+        
+        return analistas.stream()
+            .map(analista -> {
+                Long quantidadeTalhoes = talhaoRepository.countByAnalistaId(analista.getId());
+                
+                return AnalistaEstatisticasDto.builder()
+                    .id(analista.getId())
+                    .nome(analista.getNome())
+                    .email(analista.getEmail())
+                    .quantidadeTalhoes(quantidadeTalhoes)
+                    .horasAnalisadas(0L) // Implementar futuramente
+                    .numeroNomeAnalyst(numeroSequencial.getAndIncrement())
+                    .build();
+            })
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserResponseDto> getAnalistas() {
+        log.info("Obtendo lista de analistas");
+        return userRepository.findByTipoAcesso(User.TipoAcesso.ANALISTA)
+            .stream()
+            .map(this::convertToDto)
+            .collect(Collectors.toList());
     }
 
     private UserResponseDto convertToDto(User user) {


### PR DESCRIPTION
### Funcionalidade: Gestão e Estatísticas de Analistas

Este pull request adiciona novas funcionalidades para gerenciar e consultar estatísticas de analistas (`analistas`) no sistema.

#### Novidades:

* **Novos endpoints** no `UserController`:

  * `getAnalistas`: lista todos os analistas.
  * `getAnalistasEstatisticas`: retorna estatísticas por analista (ID, nome, email, número de talhões, etc).
* **Novo DTO**: `AnalistaEstatisticasDto`, para encapsular os dados estatísticos dos analistas.

#### Alterações nos modelos e DTOs:

* `Talhao` e `TalhaoDto` agora possuem o campo `analistaId`, criando a relação entre o talhão e o analista responsável.

#### Atualizações nos repositórios:

* Novo método no `TalhaoRepository` para contar quantos talhões estão associados a um analista.
* `UserRepository` agora permite buscar usuários por tipo de acesso (`TipoAcesso`).

#### Ajustes na camada de serviço:

* `UserService` com novos métodos para buscar analistas e suas estatísticas.
* `AreaService` atualizado para definir o `analistaId` ao criar ou atualizar um talhão.
